### PR TITLE
JUnit Test for AutoMoveTo - * Defined SmartDashboardInterface to be able to mock calls to the sma…

### DIFF
--- a/Robot2018/src/org/usfirst/frc/team199/Robot2018/OI.java
+++ b/Robot2018/src/org/usfirst/frc/team199/Robot2018/OI.java
@@ -52,9 +52,9 @@ public class OI {
 		shiftDriveTypeButton = new JoystickButton(leftJoy, getButton("Shift Drive Type", 2));
 		shiftDriveTypeButton.whenPressed(new ShiftDriveType());
 		PIDMoveButton = new JoystickButton(leftJoy, getButton("PID Move", 7));
-		PIDMoveButton.whenPressed(new PIDMove(40, Robot.dt, RobotMap.distEncAvg));
+		PIDMoveButton.whenPressed(new PIDMove(40, Robot.dt, Robot.sd, RobotMap.distEncAvg));
 		PIDTurnButton = new JoystickButton(leftJoy, getButton("PID Turn", 8));
-		PIDTurnButton.whenPressed(new PIDTurn(30, Robot.dt, RobotMap.fancyGyro));
+		PIDTurnButton.whenPressed(new PIDTurn(30, Robot.dt, RobotMap.fancyGyro, Robot.sd));
 
 		rightJoy = new Joystick(1);
 		updatePIDConstantsButton = new JoystickButton(rightJoy, getButton("Get PID Constants", 8));

--- a/Robot2018/src/org/usfirst/frc/team199/Robot2018/Robot.java
+++ b/Robot2018/src/org/usfirst/frc/team199/Robot2018/Robot.java
@@ -48,12 +48,18 @@ public class Robot extends TimedRobot {
 	SendableChooser<Position> posChooser = new SendableChooser<Position>();
 	Map<String, SendableChooser<Strategy>> stratChoosers = new HashMap<String, SendableChooser<Strategy>>();
 	String[] fmsPossibilities = {"LL", "LR", "RL", "RR"};
+		
+	public static SmartDashboardInterface sd = new SmartDashboardInterface() {
+		public double getConst(String key, double def) {
+			if (!SmartDashboard.containsKey("Const/" + key)) {
+				SmartDashboard.putNumber("Const/" + key, def);
+			}
+			return SmartDashboard.getNumber("Const/" + key, def);
+		}		
+	};
 
 	public static double getConst(String key, double def) {
-		if (!SmartDashboard.containsKey("Const/" + key)) {
-			SmartDashboard.putNumber("Const/" + key, def);
-		}
-		return SmartDashboard.getNumber("Const/" + key, def);
+		return sd.getConst(key, def);
 	}
 
 	public static boolean getBool(String key, boolean def) {

--- a/Robot2018/src/org/usfirst/frc/team199/Robot2018/SmartDashboardInterface.java
+++ b/Robot2018/src/org/usfirst/frc/team199/Robot2018/SmartDashboardInterface.java
@@ -1,0 +1,5 @@
+package org.usfirst.frc.team199.Robot2018;
+
+public interface SmartDashboardInterface {
+	public double getConst(String key, double def);
+}

--- a/Robot2018/src/org/usfirst/frc/team199/Robot2018/commands/AutoMoveTo.java
+++ b/Robot2018/src/org/usfirst/frc/team199/Robot2018/commands/AutoMoveTo.java
@@ -1,8 +1,11 @@
 package org.usfirst.frc.team199.Robot2018.commands;
 
-import org.usfirst.frc.team199.Robot2018.Robot;
+import edu.wpi.first.wpilibj.PIDSource;
+
+import org.usfirst.frc.team199.Robot2018.SmartDashboardInterface;
 import org.usfirst.frc.team199.Robot2018.autonomous.AutoUtils;
 import org.usfirst.frc.team199.Robot2018.autonomous.PIDSourceAverage;
+import org.usfirst.frc.team199.Robot2018.subsystems.DrivetrainInterface;
 
 //import org.usfirst.frc.team199.Robot2018.subsystems.Drivetrain;
 
@@ -13,24 +16,25 @@ import edu.wpi.first.wpilibj.command.CommandGroup;
  */
 public class AutoMoveTo extends CommandGroup {
 	
-    public AutoMoveTo(String[] args) {
+    public AutoMoveTo(String[] args, DrivetrainInterface dt, 
+    		SmartDashboardInterface sd, PIDSource pidMoveSrc) {
         //requires(Drivetrain);
     	double rotation;
-    	double[] point;
+    	double[] point = {0,0};
     	String parentheseless;
     	String[] pointparts;
     	for (String arg : args) {
     		if (AutoUtils.isDouble(arg)) {
     			rotation = Double.valueOf(arg);
-    			addSequential(new PIDTurn(rotation - AutoUtils.getRot(), Robot.dt, Robot.dt.getGyro()));
+    			addSequential(new PIDTurn(rotation - AutoUtils.getRot(), dt, dt.getGyro(), sd));
     			AutoUtils.setRot(rotation);
     		} else if (AutoUtils.isPoint(arg)) {
     			parentheseless = arg.substring(1, arg.length() - 1);
     			pointparts = parentheseless.split(",");
     			point[0] = Double.parseDouble(pointparts[0]);
     			point[1] = Double.parseDouble(pointparts[1]);
-    			addSequential(new PIDTurn(Math.toDegrees(Math.atan((point[0] - AutoUtils.getX())/(point[1] - AutoUtils.getY())) - AutoUtils.getRot()), Robot.dt, Robot.dt.getGyro()));
-    			addSequential(new PIDMove(Math.sqrt(((point[0] - AutoUtils.getX()) * (point[0] - AutoUtils.getX()) + ((point[1] - AutoUtils.getY()) * (point[1] - AutoUtils.getY())))), Robot.dt, new PIDSourceAverage(null, null)));
+    			addSequential(new PIDTurn(Math.toDegrees(Math.atan((point[0] - AutoUtils.getX())/(point[1] - AutoUtils.getY())) - AutoUtils.getRot()), dt, dt.getGyro(), sd));
+    			addSequential(new PIDMove(Math.sqrt(((point[0] - AutoUtils.getX()) * (point[0] - AutoUtils.getX()) + ((point[1] - AutoUtils.getY()) * (point[1] - AutoUtils.getY())))), dt, sd, pidMoveSrc));
     			AutoUtils.setX(point[0]);
     			AutoUtils.setY(point[1]);
     			AutoUtils.setRot(Math.toDegrees(Math.atan((point[0] - AutoUtils.getX())/(point[1] - AutoUtils.getY()))));

--- a/Robot2018/src/org/usfirst/frc/team199/Robot2018/commands/PIDMove.java
+++ b/Robot2018/src/org/usfirst/frc/team199/Robot2018/commands/PIDMove.java
@@ -1,10 +1,12 @@
 package org.usfirst.frc.team199.Robot2018.commands;
 
 import org.usfirst.frc.team199.Robot2018.Robot;
+import org.usfirst.frc.team199.Robot2018.SmartDashboardInterface;
 import org.usfirst.frc.team199.Robot2018.autonomous.PIDSourceAverage;
 import org.usfirst.frc.team199.Robot2018.subsystems.DrivetrainInterface;
 
 import edu.wpi.first.wpilibj.PIDController;
+import edu.wpi.first.wpilibj.PIDSource;
 import edu.wpi.first.wpilibj.PIDOutput;
 import edu.wpi.first.wpilibj.command.Command;
 
@@ -17,14 +19,16 @@ public class PIDMove extends Command implements PIDOutput {
 	private DrivetrainInterface dt;
 	private PIDController moveController;
 
-	public PIDMove(double targ, DrivetrainInterface dt, PIDSourceAverage avg) {
+	public PIDMove(double targ, DrivetrainInterface dt, SmartDashboardInterface sd, PIDSource avg) {
 		// Use requires() here to declare subsystem dependencies
 		// eg. requires(chassis);
 		target = targ;
 		this.dt = dt;
-		requires(Robot.dt);
-		moveController = new PIDController(Robot.getConst("MovekP", 1), Robot.getConst("MovekI", 0),
-				Robot.getConst("MovekD", 0), avg, this);
+		if (Robot.dt != null) {
+			requires(Robot.dt);
+		}
+		moveController = new PIDController(sd.getConst("MovekP", 1), sd.getConst("MovekI", 0),
+			sd.getConst("MovekD", 0), avg, this);
 	}
 
 	// Called just before this Command runs the first time

--- a/Robot2018/src/org/usfirst/frc/team199/Robot2018/commands/PIDTurn.java
+++ b/Robot2018/src/org/usfirst/frc/team199/Robot2018/commands/PIDTurn.java
@@ -1,11 +1,11 @@
 package org.usfirst.frc.team199.Robot2018.commands;
 
 import org.usfirst.frc.team199.Robot2018.Robot;
+import org.usfirst.frc.team199.Robot2018.SmartDashboardInterface;
 import org.usfirst.frc.team199.Robot2018.subsystems.DrivetrainInterface;
 
-import com.kauailabs.navx.frc.AHRS;
-
 import edu.wpi.first.wpilibj.PIDController;
+import edu.wpi.first.wpilibj.PIDSource;
 import edu.wpi.first.wpilibj.PIDOutput;
 import edu.wpi.first.wpilibj.command.Command;
 
@@ -18,14 +18,16 @@ public class PIDTurn extends Command implements PIDOutput {
 	DrivetrainInterface dt;
 	private PIDController turnController;
 
-	public PIDTurn(double targ, DrivetrainInterface dt, AHRS ahrs) {
+	public PIDTurn(double targ, DrivetrainInterface dt, PIDSource ahrs, SmartDashboardInterface sd) {
 		// Use requires() here to declare subsystem dependencies
 		// eg. requires(chassis);
 		target = targ;
 		this.dt = dt;
-		requires(Robot.dt);
-		turnController = new PIDController(Robot.getConst("TurnkP", 1), Robot.getConst("TurnkI", 0),
-				Robot.getConst("TurnkD", 0), ahrs, this);
+		if (Robot.dt != null) {
+			requires(Robot.dt);
+		}
+		turnController = new PIDController(sd.getConst("TurnkP", 1), sd.getConst("TurnkI", 0),
+			sd.getConst("TurnkD", 0), ahrs, this);
 	}
 
 	// Called just before this Command runs the first time

--- a/Robot2018/src/org/usfirst/frc/team199/Robot2018/commands/RunScript.java
+++ b/Robot2018/src/org/usfirst/frc/team199/Robot2018/commands/RunScript.java
@@ -23,13 +23,13 @@ public class RunScript extends CommandGroup {
     			
     			switch (cmdName) {
 	    			case "moveto":
-	    				addSequential(new AutoMoveTo(cmdArgs.split(" ")));
+	    				addSequential(new AutoMoveTo(cmdArgs.split(" "), Robot.dt, Robot.sd, new PIDSourceAverage(null, null)));
 	    				break;
 	    			case "turn":
-	    				addSequential(new PIDTurn(Double.parseDouble(cmdArgs), Robot.dt, Robot.dt.getGyro()));
+	    				addSequential(new PIDTurn(Double.parseDouble(cmdArgs), Robot.dt, Robot.dt.getGyro(), Robot.sd));
 	    				break;
 	    			case "move":
-	    				addSequential(new PIDMove(Double.parseDouble(cmdArgs), Robot.dt, new PIDSourceAverage(null, null))));
+	    				addSequential(new PIDMove(Double.parseDouble(cmdArgs), Robot.dt, Robot.sd, new PIDSourceAverage(null, null)));
 	    				break;
 	    			case "switch":
 	    				addSequential(new EjectToSwitch());

--- a/Robot2018/src/org/usfirst/frc/team199/Robot2018/subsystems/Drivetrain.java
+++ b/Robot2018/src/org/usfirst/frc/team199/Robot2018/subsystems/Drivetrain.java
@@ -18,6 +18,7 @@ import com.kauailabs.navx.frc.AHRS;
 import edu.wpi.first.wpilibj.DoubleSolenoid;
 import edu.wpi.first.wpilibj.Encoder;
 import edu.wpi.first.wpilibj.SpeedControllerGroup;
+import edu.wpi.first.wpilibj.PIDSource;
 import edu.wpi.first.wpilibj.command.Subsystem;
 import edu.wpi.first.wpilibj.drive.DifferentialDrive;
 
@@ -231,11 +232,12 @@ public class Drivetrain extends Subsystem implements DrivetrainInterface {
 	public void shiftGearSolenoidOff() {
 		dtGear.set(DoubleSolenoid.Value.kOff);
 	}
+	
 	/**
 	 * Returns the gyroscope
 	 * @return the gyroscope
 	 */
-	public AHRS getGyro() {
+	public PIDSource getGyro() {
 		return fancyGyro;
 	}
 }

--- a/Robot2018/src/org/usfirst/frc/team199/Robot2018/subsystems/DrivetrainInterface.java
+++ b/Robot2018/src/org/usfirst/frc/team199/Robot2018/subsystems/DrivetrainInterface.java
@@ -1,5 +1,7 @@
 package org.usfirst.frc.team199.Robot2018.subsystems;
 
+import edu.wpi.first.wpilibj.PIDSource;
+
 public interface DrivetrainInterface {
 
 	public void initDefaultCommand();
@@ -124,4 +126,10 @@ public interface DrivetrainInterface {
 	 * Stops the solenoid that pushes the drivetrain into low or high gear
 	 */
 	public void shiftGearSolenoidOff();
+
+	/**
+	 * Returns the gyroscope
+	 * @return the gyroscope
+	 */
+	public PIDSource getGyro();
 }

--- a/Robot2018/test/org/usfirst/frc/team199/Robot2018/AutoMoveToTest.java
+++ b/Robot2018/test/org/usfirst/frc/team199/Robot2018/AutoMoveToTest.java
@@ -1,0 +1,115 @@
+package org.usfirst.frc.team199.Robot2018;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.mockito.Mockito.*;
+
+import edu.wpi.first.wpilibj.command.Command;
+import edu.wpi.first.wpilibj.command.CommandGroup;
+import edu.wpi.first.wpilibj.command.Subsystem;
+import edu.wpi.first.wpilibj.internal.HardwareTimer;
+import edu.wpi.first.wpilibj.HLUsageReporting;
+import edu.wpi.first.wpilibj.PIDController;
+import edu.wpi.first.wpilibj.PIDSource;
+import edu.wpi.first.wpilibj.PIDSourceType;
+import edu.wpi.first.wpilibj.Timer;
+import edu.wpi.first.wpilibj.PIDOutput;
+import edu.wpi.first.wpilibj.livewindow.LiveWindow;
+
+import com.kauailabs.navx.frc.AHRS;
+
+import org.usfirst.frc.team199.Robot2018.commands.Autonomous;
+import org.usfirst.frc.team199.Robot2018.commands.TeleopDrive;
+import org.usfirst.frc.team199.Robot2018.commands.Autonomous.Position;
+import org.usfirst.frc.team199.Robot2018.commands.Autonomous.Strategy;
+import org.usfirst.frc.team199.Robot2018.subsystems.DrivetrainInterface;
+import org.usfirst.frc.team199.Robot2018.autonomous.AutoUtils;
+import org.usfirst.frc.team199.Robot2018.commands.AutoMoveTo;
+
+import java.util.HashMap;
+import java.util.Map;
+
+class AutoMoveToTest {
+
+	// May need a BeforeEach to reset AutoUtils.
+
+	@BeforeEach
+	void setUp() {
+		// Since VelocityPIDController extends PIDController and PIDController calls
+		// static methods in wpilib that only work on robot,
+		// we setup these mocks to allow the tests to run off robot.
+		HardwareTimer tim = mock(HardwareTimer.class);
+		Timer.Interface timerInstance = mock(Timer.Interface.class);
+		when(tim.newTimer()).thenReturn(timerInstance);
+		Timer.SetImplementation(tim);
+		HLUsageReporting.Interface usageReporter = mock(HLUsageReporting.Interface.class);
+		HLUsageReporting.SetImplementation(usageReporter);
+	}
+	
+	@Test
+	void testWPICommand() {
+		Command command = new Command() {
+			protected boolean isFinished() { return false; }			
+		};
+		assertNotNull(command);
+	}
+	
+	@Test
+	void testWPICommandGroup() {
+		CommandGroup group = new CommandGroup();
+		assertNotNull(group);
+
+		Command command = new Command() {
+			protected boolean isFinished() { return false; }			
+		};
+		group.addSequential(command);
+	}
+	
+	@Test
+	void testPIDController() {
+		PIDSource source = mock(PIDSource.class);
+		PIDOutput output = mock(PIDOutput.class);		
+		
+		PIDController ctrl = new PIDController(0, 0, 0, source, output);
+		assertNotNull(ctrl);
+	}
+	
+	//@Test
+	// Problem instantiating Subsystem because of SendableBase using network tables.
+	void testWPISubsystem() {
+		//LiveWindow.setEnabled(false);
+		Subsystem subsystem = new Subsystem() {
+			protected void initDefaultCommand() {
+				setDefaultCommand(new Command() {
+					protected boolean isFinished() { return false; }			
+				});
+			}
+		};
+		assertNotNull(subsystem);
+	}
+		
+	@Test
+	void testForwardAndRight() {
+		String[] args = {"(0,12)","(12,12)"};
+		
+		AutoUtils.setRot(0);
+		AutoUtils.setX(0);
+		AutoUtils.setY(0);
+		
+		PIDSource pidGyroSrc = mock(PIDSource.class);
+		when(pidGyroSrc.getPIDSourceType()).thenReturn(PIDSourceType.kDisplacement);
+		DrivetrainInterface dt = mock(DrivetrainInterface.class);
+		when(dt.getGyro()).thenReturn(pidGyroSrc);		
+		SmartDashboardInterface sd = mock(SmartDashboardInterface.class);
+		PIDSource pidMoveSrc = mock(PIDSource.class);
+		
+		AutoMoveTo testAMT = new AutoMoveTo(args, dt, sd, pidMoveSrc);
+		
+		assertEquals(90, AutoUtils.getRot());
+		assertEquals(12, AutoUtils.getX());
+		assertEquals(12, AutoUtils.getY());
+	}
+}


### PR DESCRIPTION
…rt dashboard.

* Refactored AutoMoveTo to be able to unit test.  The test fails and the AutoMoveTo logic needs to be fixed.
* Refactored PIDMove to use the SD interface and use PIDSource instead.  requires() is called only if the dt exists.
* Refactored PIDTurn to use the SD interface and use the gyro PIDSource interface instead.  requires() is called only if the dt exists.
* RunScript was refactored to pass the necessary parameters to PIDMove, PIDTurn, and AutoMoveTo.
* Drivetrain (and interface) return the gyro’s PIDSource.
* Wrote the AutoMoveToTest unit test.